### PR TITLE
Add CentOS8 VM kickstarts and fixes

### DIFF
--- a/build_lustre_centos8_latest.sh
+++ b/build_lustre_centos8_latest.sh
@@ -7,7 +7,7 @@ shopt -s expand_aliases
 #### LOCAL BUILD ENV
 ### TX2 BUILD
 NPROC=12
-USER=bgerdeb
+USER="$(whoami)"
 ROOT="/home/$USER"
 DIR_HOME="$ROOT/lustre_build"
 alias l_make="$MAKE_ENV make -C"  
@@ -32,7 +32,7 @@ SPL_URL="https://github.com/zfsonlinux/zfs/releases/download/zfs-$ZFS_VERSION/sp
 DIR_E2PROGS="$DIR_HOME/e2fsprogs"
 DIR_E2PROGS_SRC="$DIR_E2PROGS/e2fsprogs"
 E2FSPROGS_PACKAGING_URL="http://archive.ubuntu.com/ubuntu/pool/main/e/e2fsprogs/e2fsprogs_1.44.6-1.debian.tar.xz"
-DIR_RPMBUILD="/home/bgerdeb/rpmbuild/RPMS/aarch64/"
+DIR_RPMBUILD="/home/$USER/rpmbuild/RPMS/aarch64/"
 
 #### LUSTRE BUILD ENV
 DIR_LUSTRE="$DIR_HOME/lustre"
@@ -41,7 +41,7 @@ LUSTRE_BRANCH="lustre-arm"
 
 
 #### BUILD
-DIR_KERNEL="/home/bgerdeb/rpmbuild/BUILD/kernel-4.18.0-80.11.2.el8_0/linux-4.18.0-80.11.2.el8.aarch64/"
+DIR_KERNEL="/home/$USER/rpmbuild/BUILD/kernel-4.18.0-80.11.2.el8_0/linux-4.18.0-80.11.2.el8.aarch64/"
 
 mkdir -p $DIR_HOME
 mkdir -p $DIR_REPO
@@ -65,8 +65,19 @@ function isinstalled {
 # For CentOS 8 srpms seem slow to be uploaded... But sources (i.e linux tarball, kabi stuff) looks the same as RHEL8's, so reused those.
 # Linaro HPC SIG has a SRPM of the latest kernel on the hpc-fileserver
 # Kernel spec deps:
-# sudo yum install --enablerepo="PowerTools" -y audit-libs-devel binutils-devel elfutils-devel java-devel kabi-dw ncurses-devel newt-devel numactl-devel openssl-devel pciutils-devel perl-devel python3-devel python3-docutils xmlto xz-devel zlib-devel perl-ExtUtils-Embed
+# sudo yum install --enablerepo="PowerTools" -y audit-libs-devel binutils-devel elfutils-devel java-devel kabi-dw ncurses-devel newt-devel numactl-devel openssl-devel pciutils-devel perl-devel python3-devel python3-docutils xmlto xz-devel zlib-devel perl-ExtUtils-Embed bc net-tools
 # pdsh deps : readline-devel
+
+cat << EOF > "$DIR_HOME/lustre.repo"
+[lustre_repo]
+name=Lustre repo
+baseurl=file://$DIR_REPO
+enabled=1
+gpgcheck=0
+EOF
+
+sudo mv "$DIR_HOME/lustre.repo" "/etc/yum.repos.d/"
+sudo yum update -y
 
 sudo yum config-manager --set-enabled PowerTools
 sudo yum -y install "@Development Tools"

--- a/centos8vm/Centos8.Upstream.LustreVM.ks
+++ b/centos8vm/Centos8.Upstream.LustreVM.ks
@@ -1,0 +1,128 @@
+# Required Kernel options to install ERP CentOS7 build: 
+# ip=dhcp text inst.stage2=http://mirrors.coreix.net/centos/8/BaseOS/aarch64/os/ inst.repo=http://mirrors.coreix.net/centos/8/BaseOS/aarch64/os/ earlycon
+# Use network installation
+url --url="http://mirrors.coreix.net/centos/8/BaseOS/aarch64/os/"
+repo --name="upstream" --baseurl="http://mirrors.coreix.net/centos/8/BaseOS/aarch64/os/"
+# Use text mode install
+text
+# Do not configure the X Window System
+skipx
+
+# Keyboard layouts
+keyboard --vckeymap=us --xlayouts=''
+# System language
+lang en_US.UTF-8
+# System timezone
+timezone Europe/London
+# Root password
+rootpw --iscrypted !!
+
+# Network information
+network --bootproto=dhcp
+%include "/tmp/hostname.ks"
+
+# System services
+services --enabled="chronyd"
+
+# Install to sda.
+bootloader --append=" crashkernel=auto" --location=mbr --boot-drive=sda
+ignoredisk --only-use=sda
+autopart --type=plain
+clearpart --all --initlabel --drives=sda
+
+
+# Reboot after installation
+reboot
+
+%packages
+@core
+@Development Tools
+chrony
+kexec-tools
+git
+vim
+wget
+lvm2
+
+%end
+
+%addon com_redhat_kdump --enable --reserve-mb='auto'
+
+%end
+%pre
+#!/bin/sh
+
+echo “network -–hostname={{ hostname }}” > /tmp/hostname.ks
+for x in `cat /proc/cmdline`; do
+        case $x in SERVERNAME*)
+               eval $x
+        	   echo "network --hostname=$SERVERNAME" > /tmp/hostname.ks
+               ;;
+            esac;
+done
+%end
+%post
+#---- Install our SSH key ----
+mkdir -m0700 /root/.ssh/
+yum update -y
+
+{% for key in ssh_keys %}
+printf "{{key}}\n" >> /root/.ssh/authorized_keys ;
+{% endfor %}
+
+### Display IP on login
+echo "My IP address: \4" > /etc/issue
+
+### set permissions
+chmod 0600 /root/.ssh/authorized_keys
+
+### LUSTRE : Install dependencies for build
+yum install --enablerepo="PowerTools" -y audit-libs-devel binutils-devel elfutils-devel java-devel kabi-dw ncurses-devel newt-devel numactl-devel openssl-devel pciutils-devel perl-devel python3-devel python3-docutils xmlto xz-devel zlib-devel perl-ExtUtils-Embed readline-devel bc net-tools
+
+### LUSTRE : Disable SELinux
+sed -i "s/enforcing/disabled/g" /etc/selinux/config
+
+### LUSTRE : Create runas user with IDs 500:500
+groupadd -g 500 runas
+useradd -g 500 -m -u 500 runas
+
+### LUSTRE : Create builder user
+useradd -m builder
+usermod -a -G wheel builder
+
+### LUSTRE : Add rpm dependencies repo
+cat << EOF > /etc/yum.repos.d/lustre_deps.repo
+[lustre_deps_repo]
+name=Lustre Dependencies repo
+baseurl=http://10.40.0.13/lustre_deps/repo/
+enabled=1
+gpgcheck=0
+EOF
+
+### LUSTRE : Add e2fsprogs and lustre repo
+### NOTE: You still need to manually wget and rpm -ivh --nodeps the kmods...
+
+cat << EOF > /etc/yum.repos.d/lustre.repo
+[lustre_repo]
+name=Lustre repo
+baseurl=http://10.40.0.13/lustre/latest/
+enabled=1
+gpgcheck=0
+EOF
+
+yum update -y
+## NOTE : This update should update e2fsprogs, so if it is a bad build...
+
+### LUSTRE : Install pdsh
+yum install -y pdsh pdsh-rcmd-ssh
+
+### LUSTRE : Disable all network control
+systemctl disable firewalld
+systemctl stop firewalld
+
+### LUSTRE : Fetch kernel sources for build
+wget -P /home/builder/ http://10.40.0.13/lustre_deps/linux/kernel-latest_SOURCES.tar.gz
+cd /home/builder && tar xf kernel-latest_SOURCES.tar.gz
+
+
+%end

--- a/centos8vm/Centos8.Upstream.VM.ks
+++ b/centos8vm/Centos8.Upstream.VM.ks
@@ -1,0 +1,82 @@
+# Required Kernel options to install ERP CentOS7 build: 
+# ip=dhcp text inst.stage2=http://mirrors.coreix.net/centos/8/BaseOS/aarch64/os/ inst.repo=http://mirrors.coreix.net/centos/8/BaseOS/aarch64/os/ earlycon
+# Use network installation
+url --url="http://mirrors.coreix.net/centos/8/BaseOS/aarch64/os/"
+repo --name="upstream" --baseurl="http://mirrors.coreix.net/centos/8/BaseOS/aarch64/os/"
+# Use text mode install
+text
+# Do not configure the X Window System
+skipx
+
+# Keyboard layouts
+keyboard --vckeymap=us --xlayouts=''
+# System language
+lang en_US.UTF-8
+# System timezone
+timezone Europe/London
+# Root password
+rootpw --iscrypted !!
+
+# Network information
+network --bootproto=dhcp
+%include "/tmp/hostname.ks"
+
+# System services
+services --enabled="chronyd"
+
+# Install to sda.
+bootloader --append=" crashkernel=auto" --location=mbr --boot-drive=sda
+ignoredisk --only-use=sda
+autopart --type=plain
+clearpart --all --initlabel --drives=sda
+
+
+# Reboot after installation
+reboot
+
+%packages
+@core
+@Development Tools
+chrony
+kexec-tools
+git
+vim
+
+%end
+
+%addon com_redhat_kdump --enable --reserve-mb='auto'
+
+%end
+%pre
+#!/bin/sh
+
+echo “network -–hostname={{ hostname }}” > /tmp/hostname.ks
+for x in `cat /proc/cmdline`; do
+        case $x in SERVERNAME*)
+               eval $x
+        	   echo "network --hostname=$SERVERNAME" > /tmp/hostname.ks
+               ;;
+            esac;
+done
+%end
+%post
+#---- Install our SSH key ----
+mkdir -m0700 /root/.ssh/
+yum update -y
+
+{% for key in ssh_keys %}
+printf "{{key}}\n" >> /root/.ssh/authorized_keys ;
+{% endfor %}
+
+### Display IP on login
+echo "My IP address: \4" > /etc/issue
+
+### set permissions
+chmod 0600 /root/.ssh/authorized_keys
+
+### fix up selinux context
+#restorecon -R /root/.ssh/
+
+# Add apt-cacher-ng to conf
+#echo "proxy=http://10.40.0.13:3142" >> /etc/yum.conf
+%end

--- a/centos8vm/create_centos8_qemuvirt.sh
+++ b/centos8vm/create_centos8_qemuvirt.sh
@@ -9,10 +9,10 @@ fallocate -l 15G /var/lib/libvirt/images/"$name"ost.qcow2
 qemu-img create -f qcow2 /var/lib/libvirt/images/"$name"ost.qcow2 45G
 qemu-img create -f qcow2 /var/lib/libvirt/images/"$name".qcow2 15G
 
-num="1"
+num=${VMNUM:-"1"}
 vf=$(($num+1)) #num+1
 name="centos8$(hostname)$num"
-ib_if="ib$((16-$num))"
+ib_if=${IBVF:-"ib$((16-$num))"}
 pci_address=$(ethtool -i ${ib_if} | awk '{if(/bus-info: 0000:/) print $2}' | sed 's/0000://g')
 virt-install -d \
 	--name $name \
@@ -26,6 +26,6 @@ virt-install -d \
 	--network type=direct,source=enp1s0f0,source_mode=bridge,model=virtio \
 	--console pty \
 	--location 'http://mirrors.coreix.net/centos/8/BaseOS/aarch64/os/'  \
-	--extra-args "ks=http://10.40.0.11:5000/preseed/32" \
+	--extra-args "ks=http://10.40.0.11:5000/preseed/33 SERVERNAME=\"${name}\"" \
 	--noautoconsole --force \
 #	--boot uefi,loader=/usr/share/AAVMF/AAVMF_CODE.verbose.fd,loader_ro=yes,loader_type=pflash,nvram_template=/usr/share/AAVMF/AAVMF_VARS.fd \

--- a/centos8vm/create_centos8_qemuvirt.sh
+++ b/centos8vm/create_centos8_qemuvirt.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/bash
+
+yum install -y wget vim "@Development Tools" tk tcsh gcc-gfortran lsof python36-devel kernel-rpm-macros pciutils python36 createrepo libvirt qemu-kvm virt-install python2 AAVMF -y
+systemctl enable libvirtd
+systemctl start libvirtd
+
+fallocate -l 45G /var/lib/libvirt/images/"$name".qcow2
+fallocate -l 15G /var/lib/libvirt/images/"$name"ost.qcow2
+qemu-img create -f qcow2 /var/lib/libvirt/images/"$name"ost.qcow2 45G
+qemu-img create -f qcow2 /var/lib/libvirt/images/"$name".qcow2 15G
+
+num="1"
+vf=$(($num+1)) #num+1
+name="centos8$(hostname)$num"
+ib_if="ib$((16-$num))"
+pci_address=$(ethtool -i ${ib_if} | awk '{if(/bus-info: 0000:/) print $2}' | sed 's/0000://g')
+virt-install -d \
+	--name $name \
+	--ram 32768 \
+	--disk path=/var/lib/libvirt/images/"$name".qcow2,size=45 \
+	--disk path=/var/lib/libvirt/images/"$name"ost.qcow2,size=15 \
+	--host-device ${pci_address},driver_name="vfio",address.type="pci" \
+	--vcpus 16 \
+	--os-type linux \
+	--os-variant "rhel8.0" \
+	--network type=direct,source=enp1s0f0,source_mode=bridge,model=virtio \
+	--console pty \
+	--location 'http://mirrors.coreix.net/centos/8/BaseOS/aarch64/os/'  \
+	--extra-args "ks=http://10.40.0.11:5000/preseed/32" \
+	--noautoconsole --force \
+#	--boot uefi,loader=/usr/share/AAVMF/AAVMF_CODE.verbose.fd,loader_ro=yes,loader_type=pflash,nvram_template=/usr/share/AAVMF/AAVMF_VARS.fd \


### PR DESCRIPTION
These commits add kickstarts to provision either :
- a generic CentOS8 VM
- or a Lustre specific VM

It also adds a couple of things that were missing in the CentOS8 build script.

Note that the kickstarts should go to hpc_lab_setup, but at the moment I'll keep them here (as I'm still unsure how to go about integration into hpc_lab_setup)